### PR TITLE
fix: github orgs and ssh remote url parser

### DIFF
--- a/3_transformer.go
+++ b/3_transformer.go
@@ -82,11 +82,7 @@ func generateCommitHashURL(remoteURL *url.URL, longHash string) string {
 	}
 
 	if remoteURL != nil {
-		u, err := url.Parse(remoteURL.String())
-		if err != nil {
-			panic(fmt.Errorf("could not re-parse remote url, check git remote: %w", err))
-		}
-
+		u := *remoteURL // https://github.com/golang/go/issues/38351
 		u.Path = u.Path + "/commit/" + longHash
 
 		return fmt.Sprintf("[`%s`](%s)", shortHash, u.String())
@@ -112,7 +108,6 @@ func Transform(g *client.GitClient, splices []*ExtractSplice) ([]*TemplateContex
 	context := make([]*TemplateContext, 0)
 
 	remote, err := g.GetRemote()
-
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/3_transformer.go
+++ b/3_transformer.go
@@ -102,7 +102,7 @@ func paddingLeft(txt string, cur string) string {
 	return strings.Join(newArr, "\n")
 }
 
-var githubOrgRegex = regexp.MustCompile(`^([^@]+)@github.com:(\w+)\/(.+)$`)
+var githubOrgRegex = regexp.MustCompile(`^([^@]+)@github\.com:(\w+)\/(.+)$`)
 
 func Transform(g *client.GitClient, splices []*ExtractSplice) ([]*TemplateContext, error) {
 	context := make([]*TemplateContext, 0)


### PR DESCRIPTION
Was testing this with a private github organization, and given the string, the tool would have a nil pointer exception at the re-parsing phase of getting the commitUrl. 

Added:
- a change to no longer ignore the error but at least panic with a helpful message 
- a case statement for `file` 

This is definitely a rough fix, but something I tested while debugging the issue.